### PR TITLE
chore: add dependabot[bot] as trustedContributor

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -19,4 +19,5 @@ trustedContributors:
   - release-please[bot]
   - renovate[bot]
   - forking-renovate[bot]
+  - dependabot[bot]
   - apeabody


### PR DESCRIPTION
I noticed that dependabot is also utilized.

#### Related PRs/Issues
- #573


